### PR TITLE
using TextParser to handle the payload

### DIFF
--- a/lib/fluent/plugin/in_amqp.rb
+++ b/lib/fluent/plugin/in_amqp.rb
@@ -71,14 +71,14 @@ module Fluent
         @parser.parse msg do |_, payload|
           if payload.nil?
             log.warn "failed to parse #{msg}"
-            parsed = { "payload" => msg }
+            parsed = { "message" => msg }
           else
             parsed = payload
           end
         end
         parsed
       else
-        { "payload" => msg }
+        { "message" => msg }
       end
     end
   end # class AMQPInput


### PR DESCRIPTION
This patch uses Fluent's standard TextParser, taking the common `format` option, to handle a wider range of payload formats and to behave more like the built-in input plugins.
