### PR TITLE
Support secret parameters

### DIFF
--- a/lib/fluent/plugin/in_amqp.rb
+++ b/lib/fluent/plugin/in_amqp.rb
@@ -6,7 +6,7 @@ module Fluent
 
     config_param :host, :string, :default => nil
     config_param :user, :string, :default => "guest"
-    config_param :pass, :string, :default => "guest"
+    config_param :pass, :string, :default => "guest", :secret => true
     config_param :vhost, :string, :default => "/"
     config_param :port, :integer, :default => 5672
     config_param :ssl, :bool, :default => false

--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -4,7 +4,7 @@ module Fluent
 
     config_param :host, :string, :default => nil
     config_param :user, :string, :default => "guest"
-    config_param :pass, :string, :default => "guest"
+    config_param :pass, :string, :default => "guest", :secret => true
     config_param :vhost, :string, :default => "/"
     config_param :port, :integer, :default => 5672
     config_param :ssl, :bool, :default => false


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameters feature.
`:secret => true` specified parameters will be replaced with xxxxxx in log.

If you use older fluentd, `:secret => true` specified parameters will be simply ignored.