### PR TITLE
Enable TLS authentication for connections + Add Test Cases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,13 @@ RUN rpm -ivh https://www.rabbitmq.com/releases/rabbitmq-server/v3.5.1/rabbitmq-s
 RUN rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent
 RUN rpm -ivh http://packages.treasuredata.com.s3.amazonaws.com/2/redhat/6/x86_64/td-agent-2.3.0-0.el6.x86_64.rpm
 
-EXPOSE 5671 5672 15672 25672
+EXPOSE 5671 5672 15672 25672 20001
 
 ADD . /fluent-plugin-amqp
 WORKDIR /fluent-plugin-amqp
 RUN /opt/td-agent/embedded/bin/gem build fluent-plugin-amqp.gemspec
 RUN td-agent-gem install -VV fluent-plugin-amqp-*.gem
+
+VOLUME /fluent-plugin-amqp
 
 ENTRYPOINT ["docker/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Description goes here.
 |:tls|:bool|false| |
 |:tls_cert|:string|nil| |
 |:tls_key|:string|nil| |
-|:tls_ca_certificates|:string|nil| |
+|:tls_ca_certificates|:array|nil| |
 |:tls_verify_peer|:bool|true| |
 
 
@@ -91,7 +91,7 @@ Description goes here.
 |:tls|:bool|false| |
 |:tls_cert|:string|nil| |
 |:tls_key|:string|nil| |
-|:tls_ca_certificates|:string|nil| |
+|:tls_ca_certificates|:array|nil| |
 |:tls_verify_peer|:bool|true| |
 
 ### Enable TLS Authentication
@@ -117,11 +117,14 @@ Note: The 'source' configuration accepts the same arguments.
   tls true
   tls_key "/etc/fluent/ssl/client.key.pem"
   tls_cert "/etc/fluent/ssl/client.crt.pem"
-  tls_ca_certificates "/etc/fluent/ssl/server.cacrt.pem /another/ca/cert.file"
+  tls_ca_certificates ["/etc/fluent/ssl/server.cacrt.pem", "/another/ca/cert.file"]
   tls_verify_peer true
-  
+
 </match>
 ```
+
+## Docker Container
+
 
 ## Contributing to fluent-plugin-amqp
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Description goes here.
 |:tag_key|:bool|false| | |
 |:tag_header|:string|nil| |
 |:time_header|:string|nil| |
+|:tls|:bool|false| |
+|:tls_cert|:string|nil| |
+|:tls_key|:string|nil| |
+|:tls_ca_certificates|:string|nil| |
+|:tls_verify_peer|:bool|true| |
+
+
+
 
 ### out
 
@@ -80,6 +88,40 @@ Description goes here.
 |:tag_key|:bool|false| |
 |:tag_header|:string|nil| |
 |:time_header|:string|nil| |
+|:tls|:bool|false| |
+|:tls_cert|:string|nil| |
+|:tls_key|:string|nil| |
+|:tls_ca_certificates|:string|nil| |
+|:tls_verify_peer|:bool|true| |
+
+### Enable TLS Authentication
+
+The example below shows how you can configure TLS authentication using signed encryption keys
+which will be validated by your appropriately configured RabbitMQ installation.
+
+For more information on setting up TLS encryption, see the [Bunny TLS documentation](http://rubybunny.info/articles/tls.html)
+
+Note: The 'source' configuration accepts the same arguments.
+
+```
+<match **.**>
+  type amqp
+  key my_routing_key
+  exchange amq.direct
+  host amqp.example.com
+  port 5671              # Note that your port may change for TLS auth
+  vhost /
+  user guest
+  pass guest
+
+  tls true
+  tls_key "/etc/fluent/ssl/client.key.pem"
+  tls_cert "/etc/fluent/ssl/client.crt.pem"
+  tls_ca_certificates "/etc/fluent/ssl/server.cacrt.pem /another/ca/cert.file"
+  tls_verify_peer true
+  
+</match>
+```
 
 ## Contributing to fluent-plugin-amqp
 
@@ -96,4 +138,3 @@ Description goes here.
 Copyright (c) 2011 Hiromi Ishii. See LICENSE.txt for
 Copyright (c) 2013- github/giraffi. See LICENSE.txt for
 further details.
-

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,9 @@ require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
-  test.test_files = FileList['test/*.rb']
+  test.test_files = Dir["test/**/test_*.rb"].sort
+  test.verbose = false
+  test.warning = false
 end
 
 task :default => [:test]

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,3 +5,23 @@ $ docker run -it --rm -p 15672:15672 local/fluent-plugin-amqp
 
 open `http://${docker_ip}:15672/`. and login with `admin / password`.
 
+## Alternative configuration
+
+If you wish to test/use the AMPQ in output mode (ie matcher) then you can use
+the fluentd-out.conf in the test/fixtures directory by starting the Container
+with the following run command instead;
+
+```
+$ docker run -it --rm -p 15672:15672 -p 20001:20001 local/fluent-plugin-amqp fluentd-out.conf
+```
+
+You then need to manually create a queue bound to `amq.direct` so your messages
+will be kept by rabbitmq.
+
+You can then emit messages to the brokers using the configured TCP source, with
+a simple piped output;
+```
+$ echo '{ "test": 1}' | nc -q ${DOCKER_IP}:20001
+```
+
+Simply check RabbitMQ for any messages you've submitted (http://${DOCKER_IP}:15672/)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,7 +20,8 @@ rabbitmqctl set_permissions admin ".*" ".*" ".*"
 # yum install -y openssh-server
 # service sshd start
 
-td-agent -c /fluent-plugin-amqp/test/fixtures/fluentd.conf
+CONFIG=${1:-fluentd.conf}
+td-agent -c /fluent-plugin-amqp/test/fixtures/${CONFIG}
 
 ## To debug
 #/bin/bash

--- a/fluent-plugin-amqp.gemspec
+++ b/fluent-plugin-amqp.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<rake>)
   s.add_development_dependency(%q<minitest>, ["< 5.0.0"])
   s.add_development_dependency(%q<test-unit>, [">= 3.1.0"])
+  s.add_development_dependency(%q<bunny-mock>, [">= 1.0"])
 end

--- a/fluent-plugin-amqp.gemspec
+++ b/fluent-plugin-amqp.gemspec
@@ -32,4 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<minitest>, ["< 5.0.0"])
   s.add_development_dependency(%q<test-unit>, [">= 3.1.0"])
   s.add_development_dependency(%q<bunny-mock>, [">= 1.0"])
+  s.add_development_dependency(%q<simplecov>, [">= 0.10"])
+
 end

--- a/lib/fluent/plugin/in_amqp.rb
+++ b/lib/fluent/plugin/in_amqp.rb
@@ -9,6 +9,10 @@ module Fluent
       define_method("router") { Engine }
     end
 
+    # Bunny connection handle
+    #   - Allows mocking for test purposes
+    attr_accessor :connection
+
     config_param :tag, :string, :default => "hunter.amqp"
 
     config_param :host, :string, :default => nil
@@ -31,13 +35,14 @@ module Fluent
     config_param :tls, :bool, :default => false
     config_param :tls_cert, :string, :default => nil
     config_param :tls_key, :string, :default => nil
-    config_param :tls_ca_certificates, :string, :default => nil
+    config_param :tls_ca_certificates, :array, :default => nil
     config_param :tls_verify_peer, :bool, :default => true
 
     def initialize
       require 'bunny'
       super
     end
+
 
     def configure(conf)
       conf['format'] ||= conf['payload_format'] # legacy
@@ -53,20 +58,8 @@ module Fluent
       unless @host && @queue
         raise ConfigError, "'host' and 'queue' must be all specified."
       end
-      if @tls && !(@tls_key && @tls_cert)
-        raise ConfigError, "'tls_key' and 'tls_cert' must be all specified if tls is enabled."
-      end
-      opts = {
-        :host => @host, :port => @port, :vhost => @vhost,
-        :pass => @pass, :user => @user, :ssl => @ssl,
-        :verify_ssl => @verify_ssl, :heartbeat => @heartbeat,
-        :tls                 => @tls,
-        :tls_cert            => @tls_cert,
-        :tls_key             => @tls_key,
-        :verify_peer         => @tls_verify_peer
-      }
-      opts[:tls_ca_certificates] = Array(@tls_ca_certificates.split(' ')) if @tls_ca_certificates
-      @bunny = Bunny.new(opts)
+      check_tls_configuration
+
     end
 
     def start
@@ -75,14 +68,16 @@ module Fluent
     end
 
     def shutdown
-      @bunny.stop
-      @thread.join
+      @connection.stop
+      @connection.join
       super
     end
 
     def run
-      @bunny.start
-      @channel = @bunny.create_channel
+      # Create a new connection, unless its already been provided to us
+      @connection = Bunny.new get_connection_options unless @connection
+      @connection.start
+      @channel = @connection.create_channel
       q = @channel.queue(@queue, :passive => @passive, :durable => @durable,
                        :exclusive => @exclusive, :auto_delete => @auto_delete)
       q.subscribe do |delivery, meta, msg|
@@ -126,6 +121,29 @@ module Fluent
         Time.new.to_i
       end
     end
+
+    def check_tls_configuration()
+      if @tls
+        unless @tls_key && @tls_cert
+            raise ConfigError, "'tls_key' and 'tls_cert' must be all specified if tls is enabled."
+        end
+      end
+    end
+
+    def get_connection_options()
+      opts = {
+        :host => @host, :port => @port, :vhost => @vhost,
+        :pass => @pass, :user => @user, :ssl => @ssl,
+        :verify_ssl => @verify_ssl, :heartbeat => @heartbeat,
+        :tls                 => @tls,
+        :tls_cert            => @tls_cert,
+        :tls_key             => @tls_key,
+        :verify_peer         => @tls_verify_peer
+      }
+      opts[:tls_ca_certificates] = @tls_ca_certificates if @tls_ca_certificates
+      return opts
+    end
+
   end # class AMQPInput
 
 end # module Fluent

--- a/lib/fluent/plugin/in_amqp.rb
+++ b/lib/fluent/plugin/in_amqp.rb
@@ -69,7 +69,7 @@ module Fluent
 
     def shutdown
       @connection.stop
-      @connection.join
+      @thread.join
       super
     end
 

--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -36,9 +36,20 @@ module Fluent
       unless @key || @tag_key
         raise ConfigError, "Either 'key' or 'tag_key' must be set."
       end
-      @bunny = Bunny.new(:host => @host, :port => @port, :vhost => @vhost,
-                         :pass => @pass, :user => @user, :ssl => @ssl, :verify_ssl => @verify_ssl,
-                         :heartbeat => @heartbeat)
+      if @tls && !(@tls_key && @tls_cert)
+          raise ConfigError, "'tls_key' and 'tls_cert' must be all specified if tls is enabled."
+      end
+      opts = {
+        :host => @host, :port => @port, :vhost => @vhost,
+        :pass => @pass, :user => @user, :ssl => @ssl,
+        :verify_ssl => @verify_ssl, :heartbeat => @heartbeat,
+        :tls                 => @tls,
+        :tls_cert            => @tls_cert,
+        :tls_key             => @tls_key,
+        :verify_peer         => @tls_verify_peer
+      }
+      opts[:tls_ca_certificates] = Array(@tls_ca_certificates.split(' ')) if @tls_ca_certificates
+      @bunny = Bunny.new(opts)
     end
 
     def start

--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -3,6 +3,8 @@ module Fluent
   class AMQPOutput < BufferedOutput
     Plugin.register_output("amqp", self)
 
+    attr_accessor :connection
+
     config_param :host, :string, :default => nil
     config_param :user, :string, :default => "guest"
     config_param :pass, :string, :default => "guest", :secret => true
@@ -21,6 +23,11 @@ module Fluent
     config_param :tag_key, :bool, :default => false
     config_param :tag_header, :string, :default => nil
     config_param :time_header, :string, :default => nil
+    config_param :tls, :bool, :default => false
+    config_param :tls_cert, :string, :default => nil
+    config_param :tls_key, :string, :default => nil
+    config_param :tls_ca_certificates, :array, :default => nil
+    config_param :tls_verify_peer, :bool, :default => true
 
     def initialize
       super
@@ -30,32 +37,21 @@ module Fluent
     def configure(conf)
       super
       @conf = conf
-      unless @host && @exchange
-        raise ConfigError, "'host' and 'exchange' must be all specified."
+      unless @host
+        raise ConfigError, "'host' must be specified."
       end
       unless @key || @tag_key
         raise ConfigError, "Either 'key' or 'tag_key' must be set."
       end
-      if @tls && !(@tls_key && @tls_cert)
-          raise ConfigError, "'tls_key' and 'tls_cert' must be all specified if tls is enabled."
-      end
-      opts = {
-        :host => @host, :port => @port, :vhost => @vhost,
-        :pass => @pass, :user => @user, :ssl => @ssl,
-        :verify_ssl => @verify_ssl, :heartbeat => @heartbeat,
-        :tls                 => @tls,
-        :tls_cert            => @tls_cert,
-        :tls_key             => @tls_key,
-        :verify_peer         => @tls_verify_peer
-      }
-      opts[:tls_ca_certificates] = Array(@tls_ca_certificates.split(' ')) if @tls_ca_certificates
-      @bunny = Bunny.new(opts)
+      check_tls_configuration
     end
 
     def start
       super
-      @bunny.start
-      @channel = @bunny.create_channel
+      @connection = Bunny.new(get_connection_options) unless @connection
+
+      @connection.start
+      @channel = @connection.create_channel
       @exch = @channel.exchange(@exchange, :type => @exchange_type.intern,
                               :passive => @passive, :durable => @durable,
                               :auto_delete => @auto_delete)
@@ -63,7 +59,7 @@ module Fluent
 
     def shutdown
       super
-      @bunny.stop
+      @connection.stop
     end
 
     def format(tag, time, record)
@@ -90,6 +86,30 @@ module Fluent
         h[@tag_header] = tag if @tag_header
         h[@time_header] = Time.at(time).utc.to_s if @time_header
       end
+    end
+
+
+    private
+    def check_tls_configuration()
+      if @tls
+        unless @tls_key && @tls_cert
+            raise ConfigError, "'tls_key' and 'tls_cert' must be all specified if tls is enabled."
+        end
+      end
+    end
+
+    def get_connection_options()
+      opts = {
+        :host => @host, :port => @port, :vhost => @vhost,
+        :pass => @pass, :user => @user, :ssl => @ssl,
+        :verify_ssl => @verify_ssl, :heartbeat => @heartbeat,
+        :tls                 => @tls,
+        :tls_cert            => @tls_cert,
+        :tls_key             => @tls_key,
+        :verify_peer         => @tls_verify_peer
+      }
+      opts[:tls_ca_certificates] = @tls_ca_certificates if @tls_ca_certificates
+      return opts
     end
 
   end

--- a/test/fixtures/fluentd-out.conf
+++ b/test/fixtures/fluentd-out.conf
@@ -1,0 +1,26 @@
+# This configuration opens a TCP Port on 20001 which will accept json
+#  formatted messages and pass them onto the AMQ broker for consumption.
+#
+#  To use;
+#   1. Start agents
+#   2. Manualy create a queue bound to `amq.direct`
+#   3. echo '{ "test": 1}' | nc ${DOCKER_IP} 20001
+#   4. Check RabbitMQ for a message (http://${DOCKER_IP}:15672/) on your queue
+#
+<source>
+  @type tcp
+  tag tcp.events # required
+  format json
+  port 20001 # optional. 5170 by default
+</source>
+
+<match **.**>
+    type amqp
+    host 127.0.0.1
+    port 5672
+    vhost /
+    user admin
+    pass password
+    tag_key
+    exchange amq.direct
+</match>

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,5 +15,5 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 #require 'fluent-plugin-amqp'
 
-class Test::Unit::TestCase
-end
+
+require 'bunny-mock'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,8 @@
 require 'rubygems'
 require 'bundler'
+require 'simplecov'
+SimpleCov.start
+
 begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e

--- a/test/plugin/test_in_amqp.rb
+++ b/test/plugin/test_in_amqp.rb
@@ -1,0 +1,80 @@
+
+require_relative '../helper'
+require 'fluent/test'
+require 'fluent/plugin/in_amqp'
+
+class AMPQInputTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+
+  CONFIG = %[
+    type amqp
+    format json
+    host amqp.example.com
+    port 5672
+    vhost /
+    user guest
+    pass guest
+    queue logs
+  ]
+
+  TLS_CONFIG = CONFIG + %[
+    tls true
+    tls_key "/etc/fluent/ssl/client.key.pem"
+    tls_cert "/etc/fluent/ssl/client.crt.pem"
+    tls_ca_certificates ["/etc/fluent/ssl/server.cacrt.pem", "/another/ca/cert.file"]
+    tls_verify_peer true
+  ]
+
+  def create_driver(conf)
+    Fluent::Test::InputTestDriver.new(Fluent::AMQPInput).configure(conf)
+  end
+
+  sub_test_case 'configuration' do
+    test 'basic configuration' do
+      configs = {'basic' => CONFIG}
+      configs.merge!('tls' => TLS_CONFIG)
+
+      configs.each_pair { |k, v|
+        d = create_driver(v)
+        assert_equal "amqp.example.com", d.instance.host
+        assert_equal 5672, d.instance.port
+        assert_equal "guest", d.instance.user
+        assert_equal "/", d.instance.vhost
+      }
+    end
+
+    test 'invalid tls configuration' do
+      assert_raise_message(/'tls_key' and 'tls_cert' must be all specified if tls is enabled./) do
+        create_driver(CONFIG + %[tls true])
+      end
+    end
+
+    test 'invalid host / queue configuration' do
+      assert_raise_message(/'host' and 'queue' must be all specified./) do
+        create_driver(%[
+          type amqp
+          format json
+          host bob
+          ])
+      end
+    end
+  end
+  sub_test_case 'connection handling' do
+
+    test 'queue is created' do
+      plugin = create_driver(CONFIG).instance
+      plugin.connection = BunnyMock.new
+
+      # Start the driver and wait while it initialises the threads etc
+      plugin.start
+      10.times { sleep 0.05 }
+
+      # Should have created the 'logs' queue
+      assert_equal true, plugin.connection.queue_exists?('logs')
+    end
+
+  end
+end

--- a/test/plugin/test_out_amqp.rb
+++ b/test/plugin/test_out_amqp.rb
@@ -1,0 +1,95 @@
+
+require_relative '../helper'
+require 'fluent/test'
+require 'fluent/plugin/out_amqp'
+
+class AMPQOutputTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+
+  CONFIG = %[
+    type amqp
+    format json
+    host amqp.example.com
+    port 5672
+    vhost /
+    user guest
+    pass guest
+    exchange my_exchange
+    tag_key true
+  ]
+
+  TLS_CONFIG = CONFIG + %[
+    tls true
+    tls_key "/etc/fluent/ssl/client.key.pem"
+    tls_cert "/etc/fluent/ssl/client.crt.pem"
+    tls_ca_certificates ["/etc/fluent/ssl/server.cacrt.pem", "/another/ca/cert.file"]
+    tls_verify_peer true
+  ]
+
+  def create_driver(conf)
+    Fluent::Test::OutputTestDriver.new(Fluent::AMQPOutput).configure(conf)
+  end
+
+  sub_test_case 'configuration' do
+    test 'basic configuration' do
+      configs = {'basic' => CONFIG}
+      configs.merge!('tls' => TLS_CONFIG)
+
+      configs.each_pair { |k, v|
+        d = create_driver(v)
+        assert_equal "amqp.example.com", d.instance.host
+        assert_equal 5672, d.instance.port
+        assert_equal "guest", d.instance.user
+        assert_equal "/", d.instance.vhost
+      }
+    end
+
+    test 'invalid tls configuration' do
+      assert_raise_message(/'tls_key' and 'tls_cert' must be all specified if tls is enabled./) do
+        create_driver(CONFIG + %[tls true])
+      end
+    end
+
+    test 'invalid host configuration' do
+      assert_raise_message(/'host' must be specified./) do
+        create_driver(%[
+          type amqp
+          format json
+          tag_key true
+          ])
+      end
+    end
+
+    test 'invalid tag / tag_key configuration' do
+      assert_raise_message(/Either 'key' or 'tag_key' must be set./) do
+        create_driver(%[
+          type amqp
+          format json
+          host anywhere.example.com
+          ])
+      end
+    end
+  end
+  sub_test_case 'connection handling' do
+
+    test 'Exchange is created and bound to' do
+      plugin = create_driver(CONFIG).instance
+      plugin.connection = BunnyMock.new
+
+      # Start the driver and wait while it initialises the threads etc
+      plugin.start
+      10.times { sleep 0.05 }
+
+      # Should have created the 'logs' queue
+      assert_equal true, plugin.connection.exchange_exists?('my_exchange')
+      pend("Unable to check binding state - cant reach channel instance") {
+        chnl = plugin.somehow_get_channel
+        asset_equal true, chnl.bound_to?('my_exchange')
+      }
+    end
+
+  end
+end


### PR DESCRIPTION
Configuration of TLS is now (optionally) supported using new parameters which define the path to find certificate files required.

TLS_VERIFY_PEER is true for default security, however, like SSL_VERIFY this is configurable.

I have tested manually, and have implemented unit tests of the configuration code checks, as well as some trivial integration tests by mocking out the bunny library. simplecov has been added to provide coverage reporting of the test cases; around 80% coverage so far.

# Known issues

* If the TLS configuration is defined, but the backend refuses connection the plugin still starts and only reports an error on shutdown - don't know why - any suggestions?
* I don't check if the file defined for the keys exists, but Bunny will throw errors anyway

# Test Examples

## No TLS enabled
*starts without issue*

## TLS enabled - but missing required parameters
```
<source>
  type amqp
  host rmq.example.com
  port 5671

  vhost /
  queue test
  user guest
  pass guest

  format json

  tls true
</source>

...

2016-04-01 13:51:20 +0000 [error]: fluent/supervisor.rb:309:rescue in main_process: config error file="10-amqp-source.conf" error="'tls_key' and 'tls_cert' must be all specified if tls is enabled."

```

## TLS Configured and operational

* Starts without issue*

## TLS Configured but file missing

```
2016-04-01 13:58:57 +0000 [error]: fluent/supervisor.rb:318:rescue in main_process: unexpected error error="Neither PUB key nor PRIV key: not enough data"
```

## TLS Configured but not authenticated

Hangs and does nothing, but on shutdown reports;

```
2016-04-01 13:57:22 +0000 [warn]: fluent/root_agent.rb:123:rescue in block (2 levels) in shutdown: unexpected error while shutting down input plugin plugin=Fluent::AMQPInput plugin_id="object:a0bd4c" error_class=OpenSSL::SSL::SSLError error=#<OpenSSL::SSL::SSLError: SSL_write: certificate verify failed>
```