### PR TITLE
:tls => false hangs connections for some reason

### DIFF
--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -145,7 +145,7 @@ module Fluent
         :hosts => hosts, :port => @port, :vhost => @vhost,
         :pass => @pass, :user => @user, :ssl => @ssl,
         :verify_ssl => @verify_ssl, :heartbeat => @heartbeat,
-        :tls                 => @tls,
+        :tls                 => @tls || nil,
         :tls_cert            => @tls_cert,
         :tls_key             => @tls_key,
         :verify_peer         => @tls_verify_peer


### PR DESCRIPTION
```
  ssl true$
  tls null$
  verify_ssl false$
  tls_verify_peer false$
  tls_ca_certificates "#{File.read('/rabbit.pem')}
```

This config hangs the rabbitmq connection (it ultimately times out) when `tls: false` in the ssl config to Bunny. If `tls: nil` it works just fine, so this is a tiny patch to do just that.