### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,8 @@
 gemfile:
-- gemfiles/fluentd_0.10.gemfile
-- gemfiles/fluentd_0.12.gemfile
 - gemfiles/fluentd_0.14.gemfile
 rvm:
-  - "1.9"
-  - "2.0.0"
   - "2.1"
   - "2.2"
   - "2.3.0"
 before_install:
   - gem update bundler
-
-
-matrix:
-  exclude:
-  - rvm: "1.9"
-    gemfile: gemfiles/fluentd_0.14.gemfile
-  - rvm: "2.0.0"
-    gemfile: gemfiles/fluentd_0.14.gemfile

--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,4 @@ Rake::TestTask.new(:test) do |test|
   test.warning = false
 end
 
-task :default => [:test]
+task default: [:test]

--- a/fluent-plugin-amqp.gemspec
+++ b/fluent-plugin-amqp.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.25"
   s.summary = "AMQP input/output plugin or fluentd"
 
-  s.add_runtime_dependency(%q<fluentd>)
+  s.add_runtime_dependency(%q<fluentd>, [">= 0.14.8", "< 2"])
 
   if RUBY_VERSION < "2"
     s.add_runtime_dependency(%q<amq-protocol>, ["< 2"])
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency(%q<bunny-mock>, [">= 1.0"])
   end
 
-  s.add_development_dependency(%q<shoulda>)
+  s.add_development_dependency(%q<shoulda>, [">= 3.5.0"])
   s.add_development_dependency(%q<rake>)
   s.add_development_dependency(%q<minitest>, ["< 5.0.0"])
   s.add_development_dependency(%q<test-unit>, [">= 3.1.0"])

--- a/fluent-plugin-amqp.gemspec
+++ b/fluent-plugin-amqp.gemspec
@@ -26,15 +26,9 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency(%q<fluentd>, [">= 0.14.8", "< 2"])
 
-  if RUBY_VERSION < "2"
-    s.add_runtime_dependency(%q<amq-protocol>, ["< 2"])
-    s.add_runtime_dependency(%q<bunny>, ["< 2"])
-    s.add_runtime_dependency(%q<json>, ["< 2"])
-  else
-    s.add_runtime_dependency(%q<bunny>, [">= 1.7", "< 3"])
-    # We can use this for simple mocking, but only works on Ruby 2+
-    s.add_development_dependency(%q<bunny-mock>, [">= 1.0"])
-  end
+  s.add_runtime_dependency(%q<bunny>, [">= 1.7", "< 3"])
+  # We can use this for simple mocking, but only works on Ruby 2+
+  s.add_development_dependency(%q<bunny-mock>, [">= 1.0"])
 
   s.add_development_dependency(%q<shoulda>, [">= 3.5.0"])
   s.add_development_dependency(%q<rake>)

--- a/gemfiles/fluentd_0.10.gemfile
+++ b/gemfiles/fluentd_0.10.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "fluentd", "~> 0.10.0"
-
-gemspec :path => "../"

--- a/gemfiles/fluentd_0.12.gemfile
+++ b/gemfiles/fluentd_0.12.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "fluentd", "~> 0.12.0"
-
-gemspec :path => "../"

--- a/lib/fluent/plugin/in_amqp.rb
+++ b/lib/fluent/plugin/in_amqp.rb
@@ -1,6 +1,7 @@
 require 'time'
 require 'fluent/plugin/input'
 require 'fluent/plugin/parser'
+require 'bunny'
 
 module Fluent::Plugin
   ##
@@ -52,7 +53,6 @@ module Fluent::Plugin
 
 
     def initialize
-      require 'bunny'
       super
     end
 

--- a/lib/fluent/plugin/in_amqp.rb
+++ b/lib/fluent/plugin/in_amqp.rb
@@ -45,13 +45,6 @@ module Fluent::Plugin
     config_param :exchange, :string, default: ""
     config_param :routing_key, :string, default: "#"                       # The routing key used to bind queue to exchange - # = matches all, * matches section (tag.*.info)
 
-
-
-    def initialize
-      super
-    end
-
-
     def configure(conf)
       conf['format'] ||= conf['payload_format'] # legacy
       compat_parameters_convert(conf, :parser)

--- a/lib/fluent/plugin/in_amqp.rb
+++ b/lib/fluent/plugin/in_amqp.rb
@@ -12,11 +12,6 @@ module Fluent::Plugin
 
     helpers :compat_parameters, :parser
 
-    # Define `router` method of v0.12 to support v0.10.57 or earlier
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
-    end
-
     # Bunny connection handle
     #   - Allows mocking for test purposes
     attr_accessor :connection

--- a/lib/fluent/plugin/in_amqp.rb
+++ b/lib/fluent/plugin/in_amqp.rb
@@ -131,9 +131,9 @@ module Fluent::Plugin
 
     def parse_time( meta )
       if @time_header && meta[:headers][@time_header]
-        Time.parse( meta[:headers][@time_header] ).to_i
+        Fluent::EventTime.from_time(Time.parse( meta[:headers][@time_header] ))
       else
-        Time.new.to_i
+        Fluent::Engine.now
       end
     end
 

--- a/lib/fluent/plugin/in_amqp.rb
+++ b/lib/fluent/plugin/in_amqp.rb
@@ -20,34 +20,34 @@ module Fluent::Plugin
     #   - Allows mocking for test purposes
     attr_accessor :connection
 
-    config_param :tag, :string, :default => "hunter.amqp"
+    config_param :tag, :string, default: "hunter.amqp"
 
-    config_param :host, :string, :default => nil
-    config_param :hosts, :array, :default => nil
-    config_param :user, :string, :default => "guest"
-    config_param :pass, :string, :default => "guest", :secret => true
-    config_param :vhost, :string, :default => "/"
-    config_param :port, :integer, :default => 5672
-    config_param :ssl, :bool, :default => false
-    config_param :verify_ssl, :bool, :default => false
-    config_param :heartbeat, :integer, :default => 60
-    config_param :queue, :string, :default => nil
-    config_param :durable, :bool, :default => false
-    config_param :exclusive, :bool, :default => false
-    config_param :auto_delete, :bool, :default => false
-    config_param :passive, :bool, :default => false
-    config_param :payload_format, :string, :default => "json"
-    config_param :tag_key, :bool, :default => false
-    config_param :tag_header, :string, :default => nil
-    config_param :time_header, :string, :default => nil
-    config_param :tls, :bool, :default => false
-    config_param :tls_cert, :string, :default => nil
-    config_param :tls_key, :string, :default => nil
-    config_param :tls_ca_certificates, :array, :default => nil
-    config_param :tls_verify_peer, :bool, :default => true
-    config_param :bind_exchange, :bool, :default => false
-    config_param :exchange, :string, :default => ""
-    config_param :routing_key, :string, :default => "#"                       # The routing key used to bind queue to exchange - # = matches all, * matches section (tag.*.info)
+    config_param :host, :string, default: nil
+    config_param :hosts, :array, default: nil
+    config_param :user, :string, default: "guest"
+    config_param :pass, :string, default: "guest", secret: true
+    config_param :vhost, :string, default: "/"
+    config_param :port, :integer, default: 5672
+    config_param :ssl, :bool, default: false
+    config_param :verify_ssl, :bool, default: false
+    config_param :heartbeat, :integer, default: 60
+    config_param :queue, :string, default: nil
+    config_param :durable, :bool, default: false
+    config_param :exclusive, :bool, default: false
+    config_param :auto_delete, :bool, default: false
+    config_param :passive, :bool, default: false
+    config_param :payload_format, :string, default: "json"
+    config_param :tag_key, :bool, default: false
+    config_param :tag_header, :string, default: nil
+    config_param :time_header, :string, default: nil
+    config_param :tls, :bool, default: false
+    config_param :tls_cert, :string, default: nil
+    config_param :tls_key, :string, default: nil
+    config_param :tls_ca_certificates, :array, default: nil
+    config_param :tls_verify_peer, :bool, default: true
+    config_param :bind_exchange, :bool, default: false
+    config_param :exchange, :string, default: ""
+    config_param :routing_key, :string, default: "#"                       # The routing key used to bind queue to exchange - # = matches all, * matches section (tag.*.info)
 
 
 
@@ -81,11 +81,11 @@ module Fluent::Plugin
       @connection = Bunny.new get_connection_options unless @connection
       @connection.start
       @channel = @connection.create_channel
-      q = @channel.queue(@queue, :passive => @passive, :durable => @durable,
-                       :exclusive => @exclusive, :auto_delete => @auto_delete)
+      q = @channel.queue(@queue, passive: @passive, durable: @durable,
+                       exclusive: @exclusive, auto_delete: @auto_delete)
       if @bind_exchange
         log.info "Binding #{@queue} to #{@exchange}, :routing_key => #{@routing_key}"
-        q.bind(exchange=@exchange, :routing_key => @routing_key)
+        q.bind(exchange=@exchange, routing_key: @routing_key)
       end
 
       q.subscribe do |delivery, meta, msg|
@@ -148,13 +148,13 @@ module Fluent::Plugin
     def get_connection_options()
       hosts = @hosts ||= Array.new(1, @host)
       opts = {
-        :hosts => hosts, :port => @port, :vhost => @vhost,
-        :pass => @pass, :user => @user, :ssl => @ssl,
-        :verify_ssl => @verify_ssl, :heartbeat => @heartbeat,
-        :tls                 => @tls,
-        :tls_cert            => @tls_cert,
-        :tls_key             => @tls_key,
-        :verify_peer         => @tls_verify_peer
+        hosts: hosts, port: @port, vhost: @vhost,
+        pass: @pass, user: @user, ssl: @ssl,
+        verify_ssl: @verify_ssl, heartbeat: @heartbeat,
+        tls: @tls,
+        tls_cert: @tls_cert,
+        tls_key: @tls_key,
+        verify_peer: @tls_verify_peer
       }
       opts[:tls_ca_certificates] = @tls_ca_certificates if @tls_ca_certificates
       return opts

--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -1,6 +1,6 @@
 require 'json'
 require 'fluent/plugin/output'
-
+require "bunny"
 
 module Fluent::Plugin
   ##
@@ -51,7 +51,6 @@ module Fluent::Plugin
 
     def initialize
       super
-      require "bunny"
     end
 
     def configure(conf)

--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -49,10 +49,6 @@ module Fluent::Plugin
       config_set_default :@type, DEFAULT_BUFFER_TYPE
     end
 
-    def initialize
-      super
-    end
-
     def configure(conf)
       compat_parameters_convert(conf, :buffer)
       super

--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -86,8 +86,8 @@ module Fluent::Plugin
     end
 
     def shutdown
-      super
       @connection.stop
+      super
     end
 
     def formatted_to_msgpack_binary

--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -20,30 +20,30 @@ module Fluent::Plugin
     attr_reader :channel
 
 
-    config_param :host, :string, :default => nil
-    config_param :hosts, :array, :default => nil
-    config_param :user, :string, :default => "guest"
-    config_param :pass, :string, :default => "guest", :secret => true
-    config_param :vhost, :string, :default => "/"
-    config_param :port, :integer, :default => 5672
-    config_param :ssl, :bool, :default => false
-    config_param :verify_ssl, :bool, :default => false
-    config_param :heartbeat, :integer, :default => 60
-    config_param :exchange, :string, :default => ""
-    config_param :exchange_type, :string, :default => "direct"
-    config_param :passive, :bool, :default => false
-    config_param :durable, :bool, :default => false
-    config_param :auto_delete, :bool, :default => false
-    config_param :key, :string, :default => nil
-    config_param :persistent, :bool, :default => false
-    config_param :tag_key, :bool, :default => false
-    config_param :tag_header, :string, :default => nil
-    config_param :time_header, :string, :default => nil
-    config_param :tls, :bool, :default => false
-    config_param :tls_cert, :string, :default => nil
-    config_param :tls_key, :string, :default => nil
-    config_param :tls_ca_certificates, :array, :default => nil
-    config_param :tls_verify_peer, :bool, :default => true
+    config_param :host, :string, default: nil
+    config_param :hosts, :array, default: nil
+    config_param :user, :string, default: "guest"
+    config_param :pass, :string, default: "guest", secret: true
+    config_param :vhost, :string, default: "/"
+    config_param :port, :integer, default: 5672
+    config_param :ssl, :bool, default: false
+    config_param :verify_ssl, :bool, default: false
+    config_param :heartbeat, :integer, default: 60
+    config_param :exchange, :string, default: ""
+    config_param :exchange_type, :string, default: "direct"
+    config_param :passive, :bool, default: false
+    config_param :durable, :bool, default: false
+    config_param :auto_delete, :bool, default: false
+    config_param :key, :string, default: nil
+    config_param :persistent, :bool, default: false
+    config_param :tag_key, :bool, default: false
+    config_param :tag_header, :string, default: nil
+    config_param :time_header, :string, default: nil
+    config_param :tls, :bool, default: false
+    config_param :tls_cert, :string, default: nil
+    config_param :tls_key, :string, default: nil
+    config_param :tls_ca_certificates, :array, default: nil
+    config_param :tls_verify_peer, :bool, default: true
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -81,9 +81,9 @@ module Fluent::Plugin
 
       log.info "Creating new exchange #{@exchange}"
       @channel = @connection.create_channel
-      @exch = @channel.exchange(@exchange, :type => @exchange_type.intern,
-                              :passive => @passive, :durable => @durable,
-                              :auto_delete => @auto_delete)
+      @exch = @channel.exchange(@exchange, type: @exchange_type.intern,
+                              passive: @passive, durable: @durable,
+                              auto_delete: @auto_delete)
     end
 
     def shutdown
@@ -105,7 +105,7 @@ module Fluent::Plugin
           begin
             data = JSON.dump( data ) unless data.is_a?( String )
             log.debug "Sending message #{data}, :key => #{routing_key( tag)} :headers => #{headers(tag,time)}"
-            @exch.publish(data, :key => routing_key( tag ), :persistent => @persistent, :headers => headers( tag, time ))
+            @exch.publish(data, key: routing_key( tag ), persistent: @persistent, headers: headers( tag, time ))
           rescue JSON::GeneratorError => e
             log.error "Failure converting data object to json string: #{e.message}"
             # Debug only - otherwise we may pollute the fluent logs with unparseable events and loop
@@ -155,13 +155,13 @@ module Fluent::Plugin
     def get_connection_options()
       hosts = @hosts ||= Array.new(1, @host)
       opts = {
-        :hosts => hosts, :port => @port, :vhost => @vhost,
-        :pass => @pass, :user => @user, :ssl => @ssl,
-        :verify_ssl => @verify_ssl, :heartbeat => @heartbeat,
-        :tls                 => @tls || nil,
-        :tls_cert            => @tls_cert,
-        :tls_key             => @tls_key,
-        :verify_peer         => @tls_verify_peer
+        hosts: hosts, port: @port, vhost: @vhost,
+        pass: @pass, user: @user, ssl: @ssl,
+        verify_ssl: @verify_ssl, heartbeat: @heartbeat,
+        tls: @tls || nil,
+        tls_cert: @tls_cert,
+        tls_key: @tls_key,
+        verify_peer: @tls_verify_peer
       }
       opts[:tls_ca_certificates] = @tls_ca_certificates if @tls_ca_certificates
       return opts

--- a/test/plugin/test_in_amqp.rb
+++ b/test/plugin/test_in_amqp.rb
@@ -1,6 +1,7 @@
 
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_amqp'
 
 class AMPQInputTest < Test::Unit::TestCase
@@ -29,7 +30,7 @@ class AMPQInputTest < Test::Unit::TestCase
   ]
 
   def create_driver(conf)
-    Fluent::Test::InputTestDriver.new(Fluent::AMQPInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::AMQPInput).configure(conf)
   end
 
   sub_test_case 'configuration' do

--- a/test/plugin/test_out_amqp.rb
+++ b/test/plugin/test_out_amqp.rb
@@ -2,6 +2,7 @@
 
 require_relative '../helper'
 require 'fluent/test'
+require 'fluent/test/driver/output'
 require 'fluent/plugin/out_amqp'
 
 # Protection against optional dependency - Ruby 1.9 can't
@@ -55,8 +56,8 @@ end
     tls_verify_peer true
   ]
 
-  def create_driver(conf, tag='test')
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::AMQPOutput,tag).configure(conf)
+  def create_driver(conf)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::AMQPOutput).configure(conf)
   end
 
   sub_test_case 'configuration' do
@@ -148,9 +149,12 @@ end
       queue.bind plugin.exch, routing_key: 'test'
       # queue.test is now bound to the configured exchange
 
+      # v0.14 test driver does not permit to specify String object into #feed args.
+      es = Fluent::OneEventStream.new(Time.now.to_i, 'This is a simple string')
       # Emit an event through the plugins driver
-      @driver.emit( 'This is a simple string')
-      @driver.run
+      @driver.run(default_tag: 'test') do
+        @driver.feed(es)
+      end
 
       # Validate the message was delivered
       assert_equal 1, queue.message_count
@@ -175,8 +179,9 @@ end
 
       # Emit an event through the plugins driver
       object = { message: 'This is an event', nested: { type: 'hash', value: 'banana'} }
-      @driver.emit( object )
-      @driver.run
+      @driver.run(default_tag: 'test') do
+        @driver.feed( object )
+      end
 
       # Validate the message was delivered
       assert_equal 1, queue.message_count
@@ -202,8 +207,9 @@ end
 
       complex_string_msg = { message: '日 🕵 iPhone\xAE \u{1f60e}' }
       # Emit an event through the plugins driver
-      @driver.emit( complex_string_msg )
-      @driver.run
+      @driver.run(default_tag: 'test') do
+        @driver.feed( complex_string_msg )
+      end
 
       # Validate the message was _not_ delivered
       assert_equal 1, queue.message_count

--- a/test/plugin/test_out_amqp.rb
+++ b/test/plugin/test_out_amqp.rb
@@ -5,14 +5,7 @@ require 'fluent/test'
 require 'fluent/test/driver/output'
 require 'fluent/plugin/out_amqp'
 
-# Protection against optional dependency - Ruby 1.9 can't
-# include bunny-mock as its not supported
-begin
-  require 'bunny-mock'
-rescue LoadError
-  # Bunny-Mock requires Ruby 2+ and we're probably running on
-  # 1.9 - so the require explodes
-end
+require 'bunny-mock'
 
 class AMPQOutputTest < Test::Unit::TestCase
 


### PR DESCRIPTION
Hi, I've tried to migrate using v0.14 API.
Could you consider to start using v0.14 API in this plugin?

Please refer to [the upgrading v0.12 to v0.14 guide](http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12) in more details.

**Notice:** This PR contains breaking changes.

Since v0.14, fluentd plugins can handle nanosecond order time precision.