### PR TITLE
Fix for NoMethodError: undefined method `emit' for nil:NilClass error…

### DIFF
--- a/lib/fluent/plugin/in_amqp.rb
+++ b/lib/fluent/plugin/in_amqp.rb
@@ -79,7 +79,9 @@ module Fluent::Plugin
       q.subscribe do |delivery, meta, msg|
         log.debug "Recieved message #{@msg}"
         payload = parse_payload(msg)
-        router.emit(parse_tag(delivery, meta), parse_time(meta), payload)
+	unless router.nil?
+          router.emit(parse_tag(delivery, meta), parse_time(meta), payload)
+        end
       end
     end # AMQPInput#run
 


### PR DESCRIPTION
Fix for NoMethodError: undefined method `emit' for nil:NilClass errors with bunny 2.6.4 when exiting fluentd