### PR TITLE
Allow 'auth_mechanism' to be passed to Bunny.

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,14 +290,13 @@ Note: The 'source' configuration accepts the same arguments.
   host amqp.example.com
   port 5671              # Note that your port may change for TLS auth
   vhost /
-  user guest
-  pass guest
 
   tls true
   tls_key "/etc/fluent/ssl/client.key.pem"
   tls_cert "/etc/fluent/ssl/client.crt.pem"
   tls_ca_certificates ["/etc/fluent/ssl/server.cacrt.pem", "/another/ca/cert.file"]
   tls_verify_peer true
+  auth_mechanism EXTERNAL
 
 </match>
 ```

--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -46,6 +46,7 @@ module Fluent::Plugin
     config_param :tls_verify_peer, :bool, default: true
     config_param :content_type, :string, default: "application/octet"
     config_param :content_encoding, :string, default: nil
+    config_param :auth_mechanism, :string, default: nil
 
     config_section :header do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -232,7 +233,8 @@ module Fluent::Plugin
         tls: @tls || nil,
         tls_cert: @tls_cert,
         tls_key: @tls_key,
-        verify_peer: @tls_verify_peer
+        verify_peer: @tls_verify_peer,
+        auth_mechanism: @auth_mechanism,
       }
       opts[:tls_ca_certificates] = @tls_ca_certificates if @tls_ca_certificates
       return opts

--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -234,7 +234,7 @@ module Fluent::Plugin
         tls_cert: @tls_cert,
         tls_key: @tls_key,
         verify_peer: @tls_verify_peer,
-        auth_mechanism: @auth_mechanism,
+        auth_mechanism: @auth_mechanism
       }
       opts[:tls_ca_certificates] = @tls_ca_certificates if @tls_ca_certificates
       return opts


### PR DESCRIPTION
Setting this to EXTERNAL is required to properly auth using the rabbitmq-auth-mechanism-ssl plugin